### PR TITLE
For local builds, remove confusion with devel

### DIFF
--- a/rpm/droid-camres.spec
+++ b/rpm/droid-camres.spec
@@ -6,7 +6,7 @@ Name:      droid-camres
 %{!?qtc_make:%define qtc_make make}
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    Droid Camera resolutions
-Version:    0.0.devel
+Version:    0.0.local
 Release:    1
 Group:      Qt/Qt
 License:    WTFPL


### PR DESCRIPTION
could also use 0.0.0, but I think there's a reason you didn't in the first place ;)