### PR TITLE
Improve error handle

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,8 +90,6 @@ int main(int argc, char *argv[])
     {
         qInfo("Searching resolutions for %s...", qPrintable(cameras.at(i).first));
         QList<QPair<QString, QStringList> > res = cr.getResolutions(cameras.at(i).second, caps);
-        if (res.isEmpty())
-            return EXIT_FAILURE;
 
         resolutions.append(res);
     }

--- a/src/outputgen.cpp
+++ b/src/outputgen.cpp
@@ -71,6 +71,7 @@ void OutputGen::makeJson(const QList<QPair<QString, int> > &cameras,
     {
         if (resolutions.at(i).isEmpty())
         {
+            qWarning("Camres warning: No resolutions found for %s (%d): Configuration not set.", qPrintable(cameras.at(i).first), cameras.at(i).second);
             continue;
         }
 
@@ -162,6 +163,7 @@ void OutputGen::makeCamhw(const QList<QPair<QString, int> > &cameras,
     {
         if (resolutions.at(i).isEmpty())
         {
+            qWarning("Camres warning: No resolutions found for %s (%d): Configuration not set.", qPrintable(cameras.at(i).first), cameras.at(i).second);
             continue;
         }
 


### PR DESCRIPTION
Revert the breaking application works to make possibility to generate partial jolla-camera-hw.txt or json file when one camera is broken.
Also add information about lack of camera parameters when it is not present.